### PR TITLE
refactor(cmd,cfg): Tidy up cmd and cfg modules

### DIFF
--- a/cmd/rest-api/main.go
+++ b/cmd/rest-api/main.go
@@ -10,22 +10,26 @@ import (
 	log "github.com/inconshreveable/log15"
 )
 
-var configPath string
+var (
+	configPath string
+	bindAddr   string
+)
+
+const defaultConfigPath string = "./config.json"
 
 func init() {
 	log.Info("Initialising ObamaPhony REST API..")
 
 	/* Setup flags */
-	flag.StringVar(&configPath, "configPath",
-		"./config.json",
-		"Path to configuration file")
+	flag.StringVar(&configPath, "config",
+		defaultConfigPath, "Path to configuration file")
 	flag.Parse()
 }
 
 func main() {
 	cfg := config.LoadConfig(configPath)
 
-	bindAddr := fmt.Sprintf("%s:%d",
+	bindAddr = fmt.Sprintf("%s:%d",
 		cfg.Listener.HTTP.BindAddress,
 		cfg.Listener.HTTP.BindPort)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,21 +22,28 @@ type Config struct {
 func LoadConfig(path string) Config {
 	config := new(Config)
 
-	configFile, err := os.Open(path)
+	file, err := os.Open(path)
 	if err != nil {
 		log.Error("Unable to open configuration file.",
 			log.Ctx{"File": path,
-				"Error message": err.Error()})
-		os.Exit(1)
+				"Error": err.Error()})
+		os.Exit(-1)
 	}
-	defer configFile.Close()
 
-	jsonParser := json.NewDecoder(configFile)
-	if err = jsonParser.Decode(&config); err != nil {
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			log.Error("Could not defer file close.",
+				log.Ctx{"Error": err.Error()})
+			os.Exit(-1)
+		}
+	}(file)
+
+	if err = json.NewDecoder(file).Decode(&config); err != nil {
 		log.Error("Error parsing configuration file.",
 			log.Ctx{"File": path,
-				"Error message": err.Error()})
-		os.Exit(1)
+				"Error": err.Error()})
+		os.Exit(-1)
 	}
 
 	return *config


### PR DESCRIPTION
- Handle errors nicely.
- Refactor JSON parsing.
- Use `var` blocks, and `const` for the default configPath.